### PR TITLE
Red Hat vs. CentOS: Differentiate for htop

### DIFF
--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -13,6 +13,7 @@ console_packages:
   - ftp
   - git
   - hdparm
+  - htop
   - iotop
   - iproute
   - iptables

--- a/vars/CentOS_6.yml
+++ b/vars/CentOS_6.yml
@@ -1,0 +1,67 @@
+---
+
+# console packages
+# a list of default packages for every system
+console_packages:
+  - acl
+  - at
+  - bash-completion
+  - bind-utils
+  - bzip2
+  - dmidecode
+  - elinks
+  - ftp
+  - git
+  - hdparm
+  - iotop
+  - iproute
+  - iptables
+  - iptraf
+  - less
+  - lftp
+  - lsof
+  - lvm2
+  - mailx
+  - make
+  - man
+  - mc
+  - mlocate
+  - mutt
+  - net-tools
+  - nmap
+  - pciutils
+  - policycoreutils-python
+  - psmisc
+  - redhat-lsb-core
+  - rsync
+  - screen
+  - setools-console
+  - strace
+  - sysstat
+  - tar
+  - tcpdump
+  - telnet
+  - tmux
+  - unzip
+  - util-linux
+  - vim
+  - vim-enhanced
+  - wget
+  - yum-utils
+  - zip
+  - zsh
+
+# system bashrc
+console_bashrc: /etc/bashrc
+
+# system vimrc
+console_vimrc: /etc/vimrc
+
+# system gitconfig
+console_gitconfig: /etc/gitconfig
+
+# default editor
+console_editor_path: /usr/bin/vim
+
+# default editor link
+console_editor_link: /etc/alternatives/editor

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -13,6 +13,7 @@ console_packages:
   - ftp
   - git
   - hdparm
+  - htop
   - iotop
   - iproute
   - iptables

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,0 +1,67 @@
+---
+
+# console packages
+# a list of default packages for every system
+console_packages:
+  - acl
+  - at
+  - bash-completion
+  - bind-utils
+  - bzip2
+  - dmidecode
+  - elinks
+  - ftp
+  - git
+  - hdparm
+  - iotop
+  - iproute
+  - iptables
+  - iptraf
+  - less
+  - lftp
+  - lsof
+  - lvm2
+  - mailx
+  - make
+  - man
+  - mc
+  - mlocate
+  - mutt
+  - net-tools
+  - nmap
+  - pciutils
+  - policycoreutils-python
+  - psmisc
+  - redhat-lsb-core
+  - rsync
+  - screen
+  - setools-console
+  - strace
+  - sysstat
+  - tar
+  - tcpdump
+  - telnet
+  - tmux
+  - unzip
+  - util-linux
+  - vim
+  - vim-enhanced
+  - wget
+  - yum-utils
+  - zip
+  - zsh
+
+# system bashrc
+console_bashrc: /etc/bashrc
+
+# system vimrc
+console_vimrc: /etc/vimrc
+
+# system gitconfig
+console_gitconfig: /etc/gitconfig
+
+# default editor
+console_editor_path: /usr/bin/vim
+
+# default editor link
+console_editor_link: /etc/alternatives/editor

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -13,7 +13,6 @@ console_packages:
   - ftp
   - git
   - hdparm
-  - htop
   - iotop
   - iproute
   - iptables


### PR DESCRIPTION
##### SUMMARY

Both CentOS and pure Red Hat system's don't have htop available but only via EPEL.

Since we can't (and sometimes don't want) to include EPEL on Red Hat systems we
have to introduce a differentiation in the variable defining the required packages.

Resolves #2 

##### ISSUE TYPE

 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.5.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = [removed]
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```

##### ADDITIONAL INFORMATION

* Before the change: Applying the role on CentOS 6 and 7 should work, but fails on RHEL 7.5 systems
* After the change: Applying the role on CentOS 6 and 7 still works but also now on RHEL 7.