### PR TITLE
Split off htop to a separate (EPEL-only) list for CentOS 7

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,8 @@ console_vim_backupcopy: False
 
 # disable mouse support
 console_vim_mouse_enabled: False
+
+# Install packages from the EPEL as well:
+# XXX: This variable is defined (and set to a default) by ansible-role-epel,
+# therefore commented out here.
+#epel_repo_enabled_by_default: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,7 @@
 ---
 
-dependencies: []
+dependencies:
+  - role: adfinis-sygroup.epel
 
 galaxy_info:
   role_name: console

--- a/tasks/installation.yml
+++ b/tasks/installation.yml
@@ -4,3 +4,21 @@
   package:
     name: '{{ console_packages }}'
     state: present
+  tags:
+    - 'role::console'
+    - 'role::console:install'
+
+- name: install console related packages from epel repositories
+  package:
+    name: '{{ console_packages_epel }}'
+    state: present
+  tags:
+    - 'role::console'
+    - 'role::console:install'
+  when: epel_repo_enabled_by_default
+  # This may show a deprecation warning about bare variables on some versions of
+  # Ansible.
+  # It is a bug that was introduced in Ansible 2.8, and fixed in Ansible 2.8.2.
+  # Bug report:  https://github.com/ansible/ansible/issues/53428
+  # Bugfix MR:   https://github.com/ansible/ansible/pull/57190
+  # Backport MR: https://github.com/ansible/ansible/pull/57329

--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -13,7 +13,6 @@ console_packages:
   - ftp
   - git
   - hdparm
-  - htop
   - iotop
   - iproute
   - iptables
@@ -51,6 +50,9 @@ console_packages:
   - yum-utils
   - zip
   - zsh
+
+console_packages_epel:
+  - htop
 
 # system bashrc
 console_bashrc: /etc/bashrc


### PR DESCRIPTION
##### SUMMARY
ansible-role-console installs packages that, on CentOS, can only be found in the EPEL repos, so their existence should be verified first.

##### ISSUE TYPE
 - Bugfix Pull Request

##### ANSIBLE VERSION
```
ansible 2.8.5
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/ayekat/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.7.4 (default, Oct  4 2019, 06:57:26) [GCC 9.2.0]
```

##### ADDITIONAL INFORMATION
The ansible-role-epel [does nothing on non-Red Hat systems](https://github.com/adfinis-sygroup/ansible-role-epel/blob/master/tasks/main.yml#L6), and should therefore not cause any issues on e.g. Debian systems.