### PR TITLE
Fix mouse support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following defaults variables can be configured:
 console_vim_backupcopy: False
 
 # disable mouse support (Only Debian)
-console_vim_mouse_disable: False
+console_vim_mouse_disable: True
 ```
 
 For a list OS related variables that usually don't need to be customized have a

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ The following defaults variables can be configured:
 # Set backupcopy default to no
 console_vim_backupcopy: False
 
-# disable mouse support
-console_vim_mouse_enabled: False
+# disable mouse support (Only Debian)
+console_vim_mouse_disable: False
 ```
 
 For a list OS related variables that usually don't need to be customized have a

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,9 @@
 # Set backupcopy default to no
 console_vim_backupcopy: False
 
+# disable mouse support (Only Debian)
+console_vim_mouse_disable: True
+
 # Install packages from the EPEL as well:
 # XXX: This variable is defined (and set to a default) by ansible-role-epel,
 # therefore commented out here.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,6 @@
 # Set backupcopy default to no
 console_vim_backupcopy: False
 
-# disable mouse support
-console_vim_mouse_enabled: False
-
 # Install packages from the EPEL as well:
 # XXX: This variable is defined (and set to a default) by ansible-role-epel,
 # therefore commented out here.

--- a/templates/etc/vimrc.j2
+++ b/templates/etc/vimrc.j2
@@ -80,7 +80,7 @@ set modeline
 " make a copy of the file and overwrite the original one
 set backupcopy=yes
 {% endif %}
-{% if console_vim_mouse_disable | d(False) and ansible_os_family == 'Debian' %}
+{% if console_vim_mouse_disable | d(True) and ansible_os_family == 'Debian' %}
 let skip_defaults_vim = 1
 set mouse=
 {% endif %}

--- a/templates/etc/vimrc.j2
+++ b/templates/etc/vimrc.j2
@@ -80,3 +80,7 @@ set modeline
 " make a copy of the file and overwrite the original one
 set backupcopy=yes
 {% endif %}
+{% if console_vim_mouse_disable | d(False) and ansible_os_family == 'Debian' %}
+let skip_defaults_vim = 1
+set mouse=
+{% endif %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Disable mouse support in vim by default on Debian
<!--- If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.9.4
  config file = /home/matthiash/adsy-git/ansible-plays.src/ansible.cfg
  configured module search path = [u'/home/matthiash/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.16 (default, Oct 10 2019, 22:02:15) [GCC 8.3.0]
```